### PR TITLE
update base image to reduce cves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3-alpine3.20
+FROM python:3.12-alpine
 
 RUN \
   apk add --update git \
-  && rm -rf /var/cache/apk/*
+  && rm -rf /var/cache/apk/*p
 
 ADD app.py requirements.txt /
 
@@ -10,4 +10,4 @@ RUN pip install -r ./requirements.txt
 
 EXPOSE 8000
 
-CMD [ "python", "./app.py" ]
+CMD [ "python", "./app.py" ] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.20
 
 RUN \
   apk add --update git \


### PR DESCRIPTION
Updated to python3.12 on latest alpine version 
Cannot upgrade to python3.13 -> telnetlib is deprecated and dependancies needs it